### PR TITLE
Document required libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ This is the solution:
 PPD is fixed and works.
 Filter is provided as src (you can found a list of packages need to be installed in order to build it in the header of source).
 Also, printing of blank lines is optimized.
+
+In order to re-compile the binary (e.g. on a Raspberry Pi), the following libraries must be installed:
+
+```
+sudo apt-get install libcups2-dev libcupsimage2-dev g++ cups cups-client
+```
+
+After that, `make` and `install` do the right thing.


### PR DESCRIPTION
The binary must be recompiled on the Raspberry Pi, and make will fail unless the required libs are installed. This commit documents the command that installs the right ones.

Tested under Raspbian GNU/Linux 8.0 (jessie).
