### PR TITLE
fixes link error on rpi buster

### DIFF
--- a/rastertozj.c
+++ b/rastertozj.c
@@ -118,7 +118,7 @@ inline int getOptionChoiceIndex(const char * choiceName, ppd_file_t * ppd)
 }
 
 
-inline void initializeSettings(char * commandLineOptionSettings)
+void initializeSettings(char * commandLineOptionSettings)
 {
 	ppd_file_t *    ppd         = NULL;
 	cups_option_t * options     = NULL;


### PR DESCRIPTION

This change fixes a linking error on Raspberry Pi Buster, as follows:

```
gcc  -o rastertozj rastertozj.o -lcupsimage -lcups
/usr/bin/ld: rastertozj.o: in function `main':
rastertozj.c:(.text.startup+0x4c): undefined reference to `initializeSettings'
collect2: error: ld returned 1 exit status
make: *** [Makefile:13: rastertozj] Error 1
```

The change removes the "inline" from the function declaration:
`inline void initializeSettings(char * commandLineOptionSettings)
`

I don't totally understand this, because I thought "inline" was just a compiler hint... but anyway without this change the code won't link on a newly installed Raspberry Pi Buster (on Pi Zero W), and with this change it works great.
